### PR TITLE
:books: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Global Flags:
 ### Developer
 
 ```
-$ go get -u github.com/ebc-2in2crc/pa/...
+$ go install github.com/ebc-2in2crc/pa/...@latest
 ```
 
 ### User

--- a/README_ja.md
+++ b/README_ja.md
@@ -265,7 +265,7 @@ Global Flags:
 ### Developer
 
 ```
-$ go get -u github.com/ebc-2in2crc/pa/...
+$ go install github.com/ebc-2in2crc/pa/...@latest
 ```
 
 ### User


### PR DESCRIPTION
Since go 1.18, the `go get` command can no longer be used for installation, so it has been replaced by the `go install` command.