### PR TITLE
Add `--retry` flag

### DIFF
--- a/cmd/graph_test.go
+++ b/cmd/graph_test.go
@@ -123,8 +123,8 @@ func TestGraphCreate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -132,8 +132,8 @@ func TestGraphCreate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "This graphID already exist.",
-				IsSuccess: false,
+				Message:    "This graphID already exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -175,8 +175,8 @@ func TestGraphGetAll(t *testing.T) {
 		{
 			definitions: pixela.GraphDefinitions{
 				Result: pixela.Result{
-					Message:   "Success.",
-					IsSuccess: true,
+					Message:    "Success.",
+					IsSuccess:  true,
 					StatusCode: http.StatusOK,
 				},
 				Graphs: []pixela.GraphDefinition{
@@ -202,8 +202,8 @@ func TestGraphGetAll(t *testing.T) {
 		{
 			definitions: pixela.GraphDefinitions{
 				Result: pixela.Result{
-					Message:   "User does not exists.",
-					IsSuccess: false,
+					Message:    "User does not exists.",
+					IsSuccess:  false,
 					StatusCode: http.StatusBadRequest,
 				},
 			},
@@ -273,8 +273,8 @@ func TestGraphGet(t *testing.T) {
 		{
 			definition: pixela.GraphDefinition{
 				Result: pixela.Result{
-					Message:   "Success.",
-					IsSuccess: true,
+					Message:    "Success.",
+					IsSuccess:  true,
 					StatusCode: http.StatusOK,
 				},
 				ID:                  "graph-id",
@@ -296,8 +296,8 @@ func TestGraphGet(t *testing.T) {
 		{
 			definition: pixela.GraphDefinition{
 				Result: pixela.Result{
-					Message:   "User does not exists.",
-					IsSuccess: false,
+					Message:    "User does not exists.",
+					IsSuccess:  false,
 					StatusCode: http.StatusBadRequest,
 				},
 			},
@@ -488,8 +488,8 @@ func TestGraphStats(t *testing.T) {
 		{
 			stats: pixela.Stats{
 				Result: pixela.Result{
-					Message:   "Success.",
-					IsSuccess: true,
+					Message:    "Success.",
+					IsSuccess:  true,
 					StatusCode: http.StatusOK,
 				},
 				TotalPixelsCount: 1,
@@ -506,8 +506,8 @@ func TestGraphStats(t *testing.T) {
 		{
 			stats: pixela.Stats{
 				Result: pixela.Result{
-					Message:   "Specified graphID not exist.",
-					IsSuccess: false,
+					Message:    "Specified graphID not exist.",
+					IsSuccess:  false,
 					StatusCode: http.StatusBadRequest,
 				},
 			},
@@ -619,8 +619,8 @@ func TestGraphUpdate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -628,8 +628,8 @@ func TestGraphUpdate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified graphID not exist.",
-				IsSuccess: false,
+				Message:    "Specified graphID not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -701,8 +701,8 @@ func TestGraphDelete(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -710,8 +710,8 @@ func TestGraphDelete(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified graphID not exist.",
-				IsSuccess: false,
+				Message:    "Specified graphID not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -791,8 +791,8 @@ func TestGraphPixels(t *testing.T) {
 		{
 			pixels: pixela.Pixels{
 				Result: pixela.Result{
-					Message:   "Success.",
-					IsSuccess: true,
+					Message:    "Success.",
+					IsSuccess:  true,
 					StatusCode: http.StatusOK,
 				},
 				Pixels: []string{"20200101"},
@@ -804,8 +804,8 @@ func TestGraphPixels(t *testing.T) {
 			withBody: true,
 			pixels: pixela.Pixels{
 				Result: pixela.Result{
-					Message:   "Success.",
-					IsSuccess: true,
+					Message:    "Success.",
+					IsSuccess:  true,
 					StatusCode: http.StatusOK,
 				},
 				Pixels: []pixela.PixelWithBody{
@@ -822,8 +822,8 @@ func TestGraphPixels(t *testing.T) {
 		{
 			pixels: pixela.Pixels{
 				Result: pixela.Result{
-					Message:   "Specified graphID not exist.",
-					IsSuccess: false,
+					Message:    "Specified graphID not exist.",
+					IsSuccess:  false,
 					StatusCode: http.StatusBadRequest,
 				},
 			},
@@ -895,8 +895,8 @@ func TestGraphStopwatch(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Stopwatch start successful.",
-				IsSuccess: true,
+				Message:    "Stopwatch start successful.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -904,8 +904,8 @@ func TestGraphStopwatch(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified graphID not exist.",
-				IsSuccess: false,
+				Message:    "Specified graphID not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,

--- a/cmd/pixel_test.go
+++ b/cmd/pixel_test.go
@@ -92,8 +92,8 @@ func TestPixelCreate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -101,8 +101,8 @@ func TestPixelCreate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "This date pixel already exist.",
-				IsSuccess: false,
+				Message:    "This date pixel already exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -173,8 +173,8 @@ func TestPixelIncrement(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -182,8 +182,8 @@ func TestPixelIncrement(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified graphID not exist.",
-				IsSuccess: false,
+				Message:    "Specified graphID not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -254,8 +254,8 @@ func TestPixelDecrement(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -263,8 +263,8 @@ func TestPixelDecrement(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified graphID not exist.",
-				IsSuccess: false,
+				Message:    "Specified graphID not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -338,8 +338,8 @@ func TestPixelGet(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur: nil,
@@ -351,8 +351,8 @@ func TestPixelGet(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified pixel not found.",
-				IsSuccess: false,
+				Message:    "Specified pixel not found.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -430,8 +430,8 @@ func TestPixelUpdate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -439,8 +439,8 @@ func TestPixelUpdate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified graphID not found.",
-				IsSuccess: false,
+				Message:    "Specified graphID not found.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -513,8 +513,8 @@ func TestPixelDelete(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -522,8 +522,8 @@ func TestPixelDelete(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified pixel not found.",
-				IsSuccess: false,
+				Message:    "Specified pixel not found.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	pixela "github.com/ebc-2in2crc/pixela4go"
 	"os"
 
 	"github.com/mitchellh/go-homedir"
@@ -11,8 +12,9 @@ import (
 )
 
 var globalOptions = &struct {
-	username string
-	token    string
+	username   string
+	token      string
+	retryCount int
 }{}
 
 var rootCmd *cobra.Command
@@ -26,6 +28,9 @@ func NewCmdRoot() *cobra.Command {
 		Short:         "The Pixela Command Line Interface is a unified tool to manage your Pixela services",
 		SilenceErrors: true,
 		SilenceUsage:  true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			pixela.RetryCount = getRetry()
+		},
 	}
 
 	cobra.OnInitialize(initConfig)
@@ -38,6 +43,8 @@ func NewCmdRoot() *cobra.Command {
 	viper.BindPFlag("username", cmd.PersistentFlags().Lookup("username"))
 	cmd.PersistentFlags().StringVarP(&globalOptions.token, "token", "t", "", "Pixela user token")
 	viper.BindPFlag("token", cmd.PersistentFlags().Lookup("token"))
+	cmd.PersistentFlags().IntVarP(&globalOptions.retryCount, "retry", "r", 0, "Specify the number of retries when the API call is rejected")
+	viper.BindPFlag("retry", cmd.PersistentFlags().Lookup("retry"))
 
 	addSubCommand(cmd)
 
@@ -104,4 +111,8 @@ func getUsername() string {
 
 func getToken() string {
 	return viper.GetString("token")
+}
+
+func getRetry() int {
+	return viper.GetInt("retry")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	pixela "github.com/ebc-2in2crc/pixela4go"
 	"os"
+
+	pixela "github.com/ebc-2in2crc/pixela4go"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -13,18 +13,21 @@ func TestCmdRootFlags(t *testing.T) {
 		commandline      string
 		expectedUserName string
 		expectedToken    string
+		expectedRetry    int
 	}{
 		{
-			envs:             map[string]string{"PA_USERNAME": "pa-user", "PA_TOKEN": "pa-token"},
+			envs:             map[string]string{"PA_USERNAME": "pa-user", "PA_TOKEN": "pa-token", "PA_RETRY": "5"},
 			commandline:      "",
 			expectedUserName: "pa-user",
 			expectedToken:    "pa-token",
+			expectedRetry:    5,
 		},
 		{
-			envs:             map[string]string{"PA_USERNAME": "pa-user", "PA_TOKEN": "pa-token"},
-			commandline:      "--username=papa-user --token=papa-token",
+			envs:             map[string]string{"PA_USERNAME": "pa-user", "PA_TOKEN": "pa-token", "PA_RETRY": "5"},
+			commandline:      "--username=papa-user --token=papa-token --retry=10",
 			expectedUserName: "papa-user",
 			expectedToken:    "papa-token",
+			expectedRetry:    10,
 		},
 	}
 
@@ -41,6 +44,9 @@ func TestCmdRootFlags(t *testing.T) {
 		}
 		if getToken() != p.expectedToken {
 			t.Errorf("expected token: %s, but got %s", p.expectedToken, getToken())
+		}
+		if getRetry() != p.expectedRetry {
+			t.Errorf("expected retry: %d, but got %d", p.expectedRetry, getRetry())
 		}
 	}
 }

--- a/cmd/user_profile_test.go
+++ b/cmd/user_profile_test.go
@@ -85,8 +85,8 @@ func TestUserProfileUpdate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -94,8 +94,8 @@ func TestUserProfileUpdate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified user is not found.",
-				IsSuccess: false,
+				Message:    "Specified user is not found.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,

--- a/cmd/user_test.go
+++ b/cmd/user_test.go
@@ -95,8 +95,8 @@ func TestUserCreate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -104,8 +104,8 @@ func TestUserCreate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "This user already exist.",
-				IsSuccess: false,
+				Message:    "This user already exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -196,8 +196,8 @@ func TestUserUpdate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -205,8 +205,8 @@ func TestUserUpdate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "User foo does not exist.",
-				IsSuccess: false,
+				Message:    "User foo does not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -250,8 +250,8 @@ func TestUserDelete(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -259,8 +259,8 @@ func TestUserDelete(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "User foo does not exist.",
-				IsSuccess: false,
+				Message:    "User foo does not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,

--- a/cmd/webhook_test.go
+++ b/cmd/webhook_test.go
@@ -85,8 +85,8 @@ func TestWebhookCreate(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:       nil,
@@ -95,8 +95,8 @@ func TestWebhookCreate(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "It is necessary to specify graphID, and type.",
-				IsSuccess: false,
+				Message:    "It is necessary to specify graphID, and type.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -142,8 +142,8 @@ func TestWebhookGetAll(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur: nil,
@@ -158,8 +158,8 @@ func TestWebhookGetAll(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "User does not exist.",
-				IsSuccess: false,
+				Message:    "User does not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -231,8 +231,8 @@ func TestWebhookInvoke(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -240,8 +240,8 @@ func TestWebhookInvoke(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified user or webhook not exist.",
-				IsSuccess: false,
+				Message:    "Specified user or webhook not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,
@@ -312,8 +312,8 @@ func TestWebhookDelete(t *testing.T) {
 	}{
 		{
 			Result: pixela.Result{
-				Message:   "Success.",
-				IsSuccess: true,
+				Message:    "Success.",
+				IsSuccess:  true,
 				StatusCode: http.StatusOK,
 			},
 			occur:    nil,
@@ -321,8 +321,8 @@ func TestWebhookDelete(t *testing.T) {
 		},
 		{
 			Result: pixela.Result{
-				Message:   "Specified user or webhook not exist.",
-				IsSuccess: false,
+				Message:    "Specified user or webhook not exist.",
+				IsSuccess:  false,
 				StatusCode: http.StatusBadRequest,
 			},
 			occur:    nil,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -19,6 +19,8 @@ If you run E2E test, Set below environment variables.
 		return
 	}
 
+	os.Setenv("PA_RETRY", "20")
+
 	testE2EUserCreate(t)
 	testE2EUserUpdate(t)
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ebc-2in2crc/pa
 go 1.18
 
 require (
-	github.com/ebc-2in2crc/pixela4go v1.5.0
+	github.com/ebc-2in2crc/pixela4go v1.6.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/ebc-2in2crc/pixela4go v1.5.0 h1:UP4T0KBz+b/74oeT569hn/qoEexe01LITR0qIsK5Hdg=
 github.com/ebc-2in2crc/pixela4go v1.5.0/go.mod h1:xXDsS5Wis6GQQipkXDQACqDdMd6eUmDfP5tj/dLy5M8=
+github.com/ebc-2in2crc/pixela4go v1.6.0 h1:JVR9TB7M3lP5U7lClxgxTFqLzl3cKi20LtG5gI73CY4=
+github.com/ebc-2in2crc/pixela4go v1.6.0/go.mod h1:xXDsS5Wis6GQQipkXDQACqDdMd6eUmDfP5tj/dLy5M8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=


### PR DESCRIPTION
Add `--retry` flag.

This function is a measure for the specification added in Pixela [v1.25.0](https://help.pixe.la/en/blog/release-request-rejecting).

- Automatically retry API calls when the API returns an HTTP 503 (`{"message":"Please retry this request〜`).
- Other than HTTP 503 (`{"message":"Please retry this request〜`), for example, network errors are not automatically retried.

**Note that this function is experimental. The behavior may change or remove.**