### PR TITLE
Run E2E test with CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,3 +20,8 @@ jobs:
 
       - name: test
         run: make test
+        env:
+          PA_E2E_TEST_RUN: ON
+          PA_USERNAME: ${{ secrets.PA_USERNAME }}
+          PA_FIRST_TOKEN: ${{ secrets.PA_FIRST_TOKEN }}
+          PA_SECOND_TOKEN: ${{ secrets.PA_SECOND_TOKEN }}


### PR DESCRIPTION
Run E2E test with CI (`.github/workflows/pr.yml`).

The required secret is already set up in the repository.
