### PR TITLE
Support get latest pixel

### DIFF
--- a/cmd/pa.go
+++ b/cmd/pa.go
@@ -45,6 +45,7 @@ type pixelaGraph interface {
 	Stopwatch(input *pixela.GraphStopwatchInput) (*pixela.Result, error)
 	Add(input *pixela.GraphAddInput) (*pixela.Result, error)
 	Subtract(input *pixela.GraphSubtractInput) (*pixela.Result, error)
+	GetLatestPixel(input *pixela.GraphGetLatestPixelInput) (*pixela.GraphPixel, error)
 }
 
 type pixelaPixel interface {

--- a/e2e/e2e_graph_test.go
+++ b/e2e/e2e_graph_test.go
@@ -122,6 +122,20 @@ func testE2EGraphGetPixelDates(t *testing.T) {
 	}
 }
 
+func testE2EGraphGetLatestPixel(t *testing.T) {
+	cmd := cmd.NewCmdRoot()
+	cmd.SetOut(io.Discard)
+	commandline := "graph get-latest-pixel --id=graph-id"
+	args := strings.Split(commandline, " ")
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+
+	if err != nil {
+		t.Errorf("graph latest pixel got: %+v\nwant: nil", err)
+	}
+}
+
 func testE2EGraphStopwatch(t *testing.T) {
 	cmd := cmd.NewCmdRoot()
 	cmd.SetOut(io.Discard)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -39,6 +39,7 @@ If you run E2E test, Set below environment variables.
 	testE2EGraphAdd(t)
 	testE2EGraphSubtract(t)
 	testE2EGraphGetPixelDates(t)
+	testE2EGraphGetLatestPixel(t)
 	testE2EGraphStopwatch(t)
 
 	testE2EPixelCreate(t)


### PR DESCRIPTION
Support `GET /v1/users/<username>/graphs/<graphID>/latest`.

https://github.com/a-know/Pixela/releases/tag/v1.29.0

This PR for #39.